### PR TITLE
Reduced dependencies

### DIFF
--- a/src/productboard/Extensions/IServiceCollectionExtensions.Gdpr.cs
+++ b/src/productboard/Extensions/IServiceCollectionExtensions.Gdpr.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection.Extensions;
+﻿using Microsoft.Extensions.DependencyInjection.Extensions;
 using productboard;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -14,19 +13,11 @@ public static partial class IServiceCollectionExtensions
     /// related services to the <see cref="IServiceCollection"/>.
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> in which to register the services.</param>
-    /// <param name="configuration">A configuration object with values for a <see cref="ProductboardGdprClientOptions"/>.</param>
     /// <param name="configureOptions">A delegate that is used to configure a <see cref="ProductboardGdprClientOptions"/>.</param>
     /// <returns>An <see cref="IHttpClientBuilder" /> that can be used to configure the client.</returns>
     public static IHttpClientBuilder AddProductboardGdpr(this IServiceCollection services,
-                                                         IConfiguration? configuration = null,
                                                          Action<ProductboardGdprClientOptions>? configureOptions = null)
     {
-        // if we have a configuration, add it
-        if (configuration != null)
-        {
-            services.Configure<ProductboardGdprClientOptions>(configuration);
-        }
-
         // if we have a configuration action, add it
         if (configureOptions != null)
         {
@@ -51,31 +42,6 @@ public static partial class IServiceCollectionExtensions
         services.TryAddTransient<ProductboardGdprClient>(resolver => resolver.GetRequiredService<InjectableProductboardGdprClient>());
 
         return services.AddHttpClient<InjectableProductboardGdprClient>();
-    }
-
-    /// <summary>
-    /// Adds the <see cref="IHttpClientFactory"/> with <see cref="ProductboardGdprClient"/> and
-    /// related services to the <see cref="IServiceCollection"/>.
-    /// </summary>
-    /// <param name="services">The <see cref="IServiceCollection"/> in which to register the services.</param>
-    /// <param name="configureOptions">A delegate that is used to configure a <see cref="ProductboardGdprClientOptions"/>.</param>
-    /// <returns>An <see cref="IHttpClientBuilder" /> that can be used to configure the client.</returns>
-    public static IHttpClientBuilder AddProductboardGdpr(this IServiceCollection services,
-                                                         Action<ProductboardGdprClientOptions>? configureOptions)
-    {
-        return services.AddProductboardGdpr(null, configureOptions);
-    }
-
-    /// <summary>
-    /// Adds the <see cref="IHttpClientFactory"/> with <see cref="ProductboardGdprClient"/> and
-    /// related services to the <see cref="IServiceCollection"/>.
-    /// </summary>
-    /// <param name="services">The <see cref="IServiceCollection"/> in which to register the services.</param>
-    /// <param name="configuration">A configuration object with values for a <see cref="ProductboardGdprClientOptions"/>.</param>
-    /// <returns>An <see cref="IHttpClientBuilder" /> that can be used to configure the client.</returns>
-    public static IHttpClientBuilder AddProductboardGdpr(this IServiceCollection services, IConfiguration configuration)
-    {
-        return services.AddProductboardGdpr(configuration, null);
     }
 
     /// <summary>

--- a/src/productboard/Extensions/IServiceCollectionExtensions.cs
+++ b/src/productboard/Extensions/IServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection.Extensions;
+﻿using Microsoft.Extensions.DependencyInjection.Extensions;
 using productboard;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -14,19 +13,11 @@ public static partial class IServiceCollectionExtensions
     /// related services to the <see cref="IServiceCollection"/>.
     /// </summary>
     /// <param name="services">The <see cref="IServiceCollection"/> in which to register the services.</param>
-    /// <param name="configuration">A configuration object with values for a <see cref="ProductboardClientOptions"/>.</param>
     /// <param name="configureOptions">A delegate that is used to configure a <see cref="ProductboardClientOptions"/>.</param>
     /// <returns>An <see cref="IHttpClientBuilder" /> that can be used to configure the client.</returns>
     public static IHttpClientBuilder AddProductboard(this IServiceCollection services,
-                                                     IConfiguration? configuration = null,
                                                      Action<ProductboardClientOptions>? configureOptions = null)
     {
-        // if we have a configuration, add it
-        if (configuration != null)
-        {
-            services.Configure<ProductboardClientOptions>(configuration);
-        }
-
         // if we have a configuration action, add it
         if (configureOptions != null)
         {
@@ -51,31 +42,6 @@ public static partial class IServiceCollectionExtensions
         services.TryAddTransient<ProductboardClient>(resolver => resolver.GetRequiredService<InjectableProductboardClient>());
 
         return services.AddHttpClient<InjectableProductboardClient>();
-    }
-
-    /// <summary>
-    /// Adds the <see cref="IHttpClientFactory"/> with <see cref="ProductboardClient"/> and
-    /// related services to the <see cref="IServiceCollection"/>.
-    /// </summary>
-    /// <param name="services">The <see cref="IServiceCollection"/> in which to register the services.</param>
-    /// <param name="configureOptions">A delegate that is used to configure a <see cref="ProductboardClientOptions"/>.</param>
-    /// <returns>An <see cref="IHttpClientBuilder" /> that can be used to configure the client.</returns>
-    public static IHttpClientBuilder AddProductboard(this IServiceCollection services,
-                                                     Action<ProductboardClientOptions> configureOptions)
-    {
-        return services.AddProductboard(null, configureOptions);
-    }
-
-    /// <summary>
-    /// Adds the <see cref="IHttpClientFactory"/> with <see cref="ProductboardClient"/> and
-    /// related services to the <see cref="IServiceCollection"/>.
-    /// </summary>
-    /// <param name="services">The <see cref="IServiceCollection"/> in which to register the services.</param>
-    /// <param name="configuration">A configuration object with values for a <see cref="ProductboardClientOptions"/>.</param>
-    /// <returns>An <see cref="IHttpClientBuilder" /> that can be used to configure the client.</returns>
-    public static IHttpClientBuilder AddProductboard(this IServiceCollection services, IConfiguration configuration)
-    {
-        return services.AddProductboard(configuration, null);
     }
 
     /// <summary>

--- a/src/productboard/productboard.csproj
+++ b/src/productboard/productboard.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">


### PR DESCRIPTION
Remove overloads that take in `IConfiguraation` instances and instead leave that to the implementor. Hence replace `Microsoft.Extensions.Options.ConfigurationExtensions` reference with `Microsoft.Extensions.Options`.