### PR TITLE
Added support for PartnerId

### DIFF
--- a/src/productboard/ProductboardClient.cs
+++ b/src/productboard/ProductboardClient.cs
@@ -192,6 +192,13 @@ public class ProductboardClient
             request.Headers.TryAddWithoutValidation("X-Version", "1");
         }
 
+        // set the partner header
+        var partnerId = options.PartnerId;
+        if (!string.IsNullOrEmpty(partnerId))
+        {
+            request.Headers.TryAddWithoutValidation("Productboard-Partner-Id", partnerId);
+        }
+
         // execute the request
         return await httpClient.SendAsync(request, cancellationToken);
     }

--- a/src/productboard/ProductboardClientOptions.cs
+++ b/src/productboard/ProductboardClientOptions.cs
@@ -37,4 +37,11 @@ public class ProductboardClientOptions
     /// </remarks>
     public string? GdprToken { get; set; }
 
+    /// <summary>
+    /// If your service integrates with Productboard and you want to take credits,
+    /// set this value with your unique partner ID to the appropriate requests.
+    /// <br/>
+    /// Please ask your Productboard representative to create or revoke your partner ID.
+    /// </summary>
+    public string? PartnerId { get; set; }
 }


### PR DESCRIPTION
Added support for setting a Partner Id in the `Productboard-Partner-Id` header with the value provided in `options.PartnerId`.